### PR TITLE
Allowing osg_parse to deal with missing values

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -59,5 +59,5 @@ LazyData: true
 Encoding: UTF-8
 License: GPL-3
 Repository: CRAN
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 VignetteBuilder: knitr

--- a/R/osg_parse.R
+++ b/R/osg_parse.R
@@ -24,11 +24,18 @@
 #'
 #'   # multiple entries
 #'   osg_parse(grid_refs = c("SN831869","SN829838"))
+#'   
+#'   # multiple entries with missing values, NA will be returned
+#'   osg_parse(grid_refs = c("SN831869",NA, "SN829838", NA))
 #' }
 #'
 
 osg_parse <- function(grid_refs, coord_system = c("BNG", "WGS84")) {
 
+    # exclude nas (if present) and retain positions
+    grid_refs <- stats::na.exclude(grid_refs)
+    na_pos <- attr(grid_refs, "na.action")
+  
     grid_refs <- toupper(as.character(grid_refs))
     coord_system <- match.arg(coord_system)
 
@@ -76,6 +83,18 @@ osg_parse <- function(grid_refs, coord_system = c("BNG", "WGS84")) {
                          from = epsg_source, to = epsg_out)
 
     colnames(xy) <- names.out
+    
+    # put the NA values back into the correct places
+    if (!is.null(na_pos)) {
+      # length of original grid_refs
+      num_elements <- length(grid_refs) + length(na_pos)
+      
+      # put valid elements in the correct positions
+      xy[c(1:num_elements)[-na_pos],] <- xy
+      
+      # add the NAs back
+      xy[na_pos,] <- NA
+    }
 
     return(as.list(xy))
 }

--- a/docs/articles/rnrfa-vignette.html
+++ b/docs/articles/rnrfa-vignette.html
@@ -76,13 +76,13 @@
 
       
 
-      </header><script src="rnrfa-vignette_files/header-attrs-2.6/header-attrs.js"></script><div class="row">
+      </header><script src="rnrfa-vignette_files/header-attrs-2.10/header-attrs.js"></script><div class="row">
   <div class="col-md-9 contents">
     <div class="page-header toc-ignore">
       <h1 data-toc-skip>An introduction to the rnrfa package</h1>
                         <h4 class="author">Claudia Vitolo</h4>
             
-            <h4 class="date">2021-03-12</h4>
+            <h4 class="date">2021-11-21</h4>
       
       <small class="dont-index">Source: <a href="https://github.com/ilapros/rnrfa/blob/master/vignettes/rnrfa-vignette.Rmd"><code>vignettes/rnrfa-vignette.Rmd</code></a></small>
       <div class="hidden name"><code>rnrfa-vignette.Rmd</code></div>
@@ -103,26 +103,26 @@
 <a href="#dependencies" class="anchor"></a>Dependencies</h3>
 <p>The rnrfa package depends on the <strong>gdal</strong> library, make sure you have it installed on your system before attempting to install this package.</p>
 <p><strong>R package dependencies</strong> can be installed running the following code:</p>
-<div class="sourceCode" id="cb1"><pre class="downlit">
-<span class="fu"><a href="https://rdrr.io/r/utils/install.packages.html">install.packages</a></span><span class="op">(</span><span class="fu"><a href="https://rdrr.io/r/base/c.html">c</a></span><span class="op">(</span><span class="st">"cowplot"</span>, <span class="st">"httr"</span>, <span class="st">"xts"</span>, <span class="st">"ggmap"</span>, <span class="st">"ggplot2"</span>, <span class="st">"sp"</span>, <span class="st">"rgdal"</span>, <span class="st">"parallel"</span>, <span class="st">"tibble"</span><span class="op">)</span><span class="op">)</span></pre></div>
+<div class="sourceCode" id="cb1"><pre class="downlit sourceCode r">
+<code class="sourceCode R"><span class="fu"><a href="https://rdrr.io/r/utils/install.packages.html">install.packages</a></span><span class="op">(</span><span class="fu"><a href="https://rdrr.io/r/base/c.html">c</a></span><span class="op">(</span><span class="st">"cowplot"</span>, <span class="st">"httr"</span>, <span class="st">"xts"</span>, <span class="st">"ggmap"</span>, <span class="st">"ggplot2"</span>, <span class="st">"sp"</span>, <span class="st">"rgdal"</span>, <span class="st">"parallel"</span>, <span class="st">"tibble"</span><span class="op">)</span><span class="op">)</span></code></pre></div>
 <p>This demo makes also use of external libraries. To install and load them run the following commands:</p>
-<div class="sourceCode" id="cb2"><pre class="downlit">
-<span class="va">packs</span> <span class="op">&lt;-</span> <span class="fu"><a href="https://rdrr.io/r/base/c.html">c</a></span><span class="op">(</span><span class="st">"devtools"</span>, <span class="st">"DT"</span>, <span class="st">"leaflet"</span><span class="op">)</span>
+<div class="sourceCode" id="cb2"><pre class="downlit sourceCode r">
+<code class="sourceCode R"><span class="va">packs</span> <span class="op">&lt;-</span> <span class="fu"><a href="https://rdrr.io/r/base/c.html">c</a></span><span class="op">(</span><span class="st">"devtools"</span>, <span class="st">"DT"</span>, <span class="st">"leaflet"</span><span class="op">)</span>
 <span class="fu"><a href="https://rdrr.io/r/utils/install.packages.html">install.packages</a></span><span class="op">(</span><span class="va">packs</span><span class="op">)</span>
-<span class="fu"><a href="https://rdrr.io/r/base/lapply.html">lapply</a></span><span class="op">(</span><span class="va">packs</span>, <span class="va">require</span>, character.only <span class="op">=</span> <span class="cn">TRUE</span><span class="op">)</span></pre></div>
+<span class="fu"><a href="https://rdrr.io/r/base/lapply.html">lapply</a></span><span class="op">(</span><span class="va">packs</span>, <span class="va">require</span>, character.only <span class="op">=</span> <span class="cn">TRUE</span><span class="op">)</span></code></pre></div>
 </div>
 <div id="installation" class="section level3">
 <h3 class="hasAnchor">
 <a href="#installation" class="anchor"></a>Installation</h3>
 <p>The stable version of the <strong>rnrfa</strong> package is available from CRAN:</p>
-<div class="sourceCode" id="cb3"><pre class="downlit">
-<span class="fu"><a href="https://rdrr.io/r/utils/install.packages.html">install.packages</a></span><span class="op">(</span><span class="st">"rnrfa"</span><span class="op">)</span></pre></div>
+<div class="sourceCode" id="cb3"><pre class="downlit sourceCode r">
+<code class="sourceCode R"><span class="fu"><a href="https://rdrr.io/r/utils/install.packages.html">install.packages</a></span><span class="op">(</span><span class="st">"rnrfa"</span><span class="op">)</span></code></pre></div>
 <p>Or you can install the development version from Github with <a href="https://github.com/r-lib/devtools">devtools</a>:</p>
-<div class="sourceCode" id="cb4"><pre class="downlit">
-<span class="fu">devtools</span><span class="fu">::</span><span class="fu"><a href="https://devtools.r-lib.org//reference/remote-reexports.html">install_github</a></span><span class="op">(</span><span class="st">"ilapros/rnrfa"</span><span class="op">)</span></pre></div>
+<div class="sourceCode" id="cb4"><pre class="downlit sourceCode r">
+<code class="sourceCode R"><span class="fu">devtools</span><span class="fu">::</span><span class="fu"><a href="https://devtools.r-lib.org//reference/remote-reexports.html">install_github</a></span><span class="op">(</span><span class="st">"ilapros/rnrfa"</span><span class="op">)</span></code></pre></div>
 <p>Now, load the rnrfa package:</p>
-<div class="sourceCode" id="cb5"><pre class="downlit">
-<span class="kw"><a href="https://rdrr.io/r/base/library.html">library</a></span><span class="op">(</span><span class="va"><a href="http://ilapros.github.io/rnrfa/">rnrfa</a></span><span class="op">)</span></pre></div>
+<div class="sourceCode" id="cb5"><pre class="downlit sourceCode r">
+<code class="sourceCode R"><span class="kw"><a href="https://rdrr.io/r/base/library.html">library</a></span><span class="op">(</span><span class="va"><a href="http://ilapros.github.io/rnrfa/">rnrfa</a></span><span class="op">)</span></code></pre></div>
 </div>
 </div>
 <div id="functions" class="section level2">
@@ -132,19 +132,19 @@
 <h3 class="hasAnchor">
 <a href="#list-of-station-identification-numbers" class="anchor"></a>List of station identification numbers</h3>
 <p>The function stations_info() returns a vector of all NRFA station identifiers.</p>
-<div class="sourceCode" id="cb6"><pre class="downlit">
-<span class="co"># Retrieve station identifiers:</span>
+<div class="sourceCode" id="cb6"><pre class="downlit sourceCode r">
+<code class="sourceCode R"><span class="co"># Retrieve station identifiers:</span>
 <span class="va">allIDs</span> <span class="op">&lt;-</span> <span class="fu"><a href="../reference/station_ids.html">station_ids</a></span><span class="op">(</span><span class="op">)</span>
-<span class="fu"><a href="https://rdrr.io/r/utils/head.html">head</a></span><span class="op">(</span><span class="va">allIDs</span><span class="op">)</span></pre></div>
+<span class="fu"><a href="https://rdrr.io/r/utils/head.html">head</a></span><span class="op">(</span><span class="va">allIDs</span><span class="op">)</span></code></pre></div>
 </div>
 <div id="list-of-monitoring-stations" class="section level3">
 <h3 class="hasAnchor">
 <a href="#list-of-monitoring-stations" class="anchor"></a>List of monitoring stations</h3>
 <p>The function catalogue() retrieves information for monitoring stations. The function, used with no inputs, requests the full list of gauging stations with associated metadata. The output is a tibble containing one record for each station and as many columns as the number of metadata entries available.</p>
-<div class="sourceCode" id="cb7"><pre class="downlit">
-<span class="co"># Retrieve information for all the stations in the catalogue:</span>
+<div class="sourceCode" id="cb7"><pre class="downlit sourceCode r">
+<code class="sourceCode R"><span class="co"># Retrieve information for all the stations in the catalogue:</span>
 <span class="va">allStations</span> <span class="op">&lt;-</span> <span class="fu"><a href="../reference/catalogue.html">catalogue</a></span><span class="op">(</span><span class="op">)</span>
-<span class="fu"><a href="https://rdrr.io/r/utils/head.html">head</a></span><span class="op">(</span><span class="va">allStations</span><span class="op">)</span></pre></div>
+<span class="fu"><a href="https://rdrr.io/r/utils/head.html">head</a></span><span class="op">(</span><span class="va">allStations</span><span class="op">)</span></code></pre></div>
 <p>The columns are briefly described below (see also <a href="https://nrfaapps.ceh.ac.uk/nrfa/nrfa-api.html#ws-station-info">API documentation</a>):</p>
 <ul>
 <li>
@@ -168,7 +168,7 @@
 <code>lat-long</code> The station latitude/longitude. For JSON output the lat-long is represented as an object with the following properties:
 <ul>
 <li>
-<code>string</code> (String) The textual representation of the lat/long (i.e. “50°48’15.0265”N 3°30’40.7121“W”).</li>
+<code>string</code> (String) The textual representation of the lat/long (i.e. “50°48’15.0265”N 3°30’40.7121”W”).</li>
 <li>
 <code>latitude</code> (Number) The latitude (expressed in decimal degrees).</li>
 <li>
@@ -206,13 +206,13 @@
 <h3 class="hasAnchor">
 <a href="#station-filtering" class="anchor"></a>Station filtering</h3>
 <p>The same function catalogue() can be used to filter stations based on a bounding box or any of the metadata entries.</p>
-<div class="sourceCode" id="cb8"><pre class="downlit">
-<span class="co"># Define a bounding box:</span>
+<div class="sourceCode" id="cb8"><pre class="downlit sourceCode r">
+<code class="sourceCode R"><span class="co"># Define a bounding box:</span>
 <span class="va">bbox</span> <span class="op">&lt;-</span> <span class="fu"><a href="https://rdrr.io/r/base/list.html">list</a></span><span class="op">(</span>lon_min <span class="op">=</span> <span class="op">-</span><span class="fl">3.82</span>, lon_max <span class="op">=</span> <span class="op">-</span><span class="fl">3.63</span>, lat_min <span class="op">=</span> <span class="fl">52.43</span>, lat_max <span class="op">=</span> <span class="fl">52.52</span><span class="op">)</span>
 <span class="co"># Filter stations based on bounding box</span>
-<span class="fu"><a href="../reference/catalogue.html">catalogue</a></span><span class="op">(</span><span class="va">bbox</span><span class="op">)</span></pre></div>
-<div class="sourceCode" id="cb9"><pre class="downlit">
-<span class="co"># Filter based on minimum recording years</span>
+<span class="fu"><a href="../reference/catalogue.html">catalogue</a></span><span class="op">(</span><span class="va">bbox</span><span class="op">)</span></code></pre></div>
+<div class="sourceCode" id="cb9"><pre class="downlit sourceCode r">
+<code class="sourceCode R"><span class="co"># Filter based on minimum recording years</span>
 <span class="fu"><a href="../reference/catalogue.html">catalogue</a></span><span class="op">(</span>min_rec <span class="op">=</span> <span class="fl">100</span><span class="op">)</span>
 
 <span class="co"># Filter stations belonging to a certain hydrometric area</span>
@@ -230,31 +230,31 @@
           min_rec <span class="op">=</span> <span class="fl">30</span><span class="op">)</span>
                                   
 <span class="co"># Filter stations based on identification number</span>
-<span class="fu"><a href="../reference/catalogue.html">catalogue</a></span><span class="op">(</span>column_name<span class="op">=</span><span class="st">"id"</span>, column_value<span class="op">=</span><span class="fu"><a href="https://rdrr.io/r/base/c.html">c</a></span><span class="op">(</span><span class="fl">3001</span>,<span class="fl">3002</span>,<span class="fl">3003</span><span class="op">)</span><span class="op">)</span></pre></div>
-<div class="sourceCode" id="cb10"><pre class="downlit">
-<span class="co"># Other combined filtering</span>
+<span class="fu"><a href="../reference/catalogue.html">catalogue</a></span><span class="op">(</span>column_name<span class="op">=</span><span class="st">"id"</span>, column_value<span class="op">=</span><span class="fu"><a href="https://rdrr.io/r/base/c.html">c</a></span><span class="op">(</span><span class="fl">3001</span>,<span class="fl">3002</span>,<span class="fl">3003</span><span class="op">)</span><span class="op">)</span></code></pre></div>
+<div class="sourceCode" id="cb10"><pre class="downlit sourceCode r">
+<code class="sourceCode R"><span class="co"># Other combined filtering</span>
 <span class="va">someStations</span> <span class="op">&lt;-</span> <span class="fu"><a href="../reference/catalogue.html">catalogue</a></span><span class="op">(</span><span class="va">bbox</span>,
                           column_name <span class="op">=</span> <span class="st">"id"</span>,
                           column_value <span class="op">=</span> <span class="fu"><a href="https://rdrr.io/r/base/c.html">c</a></span><span class="op">(</span><span class="fl">54022</span>,<span class="fl">54090</span>,<span class="fl">54091</span>,<span class="fl">54092</span>,<span class="fl">54097</span><span class="op">)</span>,
-                          min_rec <span class="op">=</span> <span class="fl">35</span><span class="op">)</span></pre></div>
+                          min_rec <span class="op">=</span> <span class="fl">35</span><span class="op">)</span></code></pre></div>
 </div>
 <div id="conversions" class="section level3">
 <h3 class="hasAnchor">
 <a href="#conversions" class="anchor"></a>Conversions</h3>
 <p>The RNRFA package allows convenient conversion between UK grid reference and more standard coordinate systems. The function “osg_parse(),” for example, converts the string to easting and northing in the BNG coordinate system (EPSG code: 27700), as in the example below:</p>
-<div class="sourceCode" id="cb11"><pre class="downlit">
-<span class="co"># Where is the first catchment located?</span>
+<div class="sourceCode" id="cb11"><pre class="downlit sourceCode r">
+<code class="sourceCode R"><span class="co"># Where is the first catchment located?</span>
 <span class="va">someStations</span><span class="op">$</span><span class="va">`grid-reference`</span><span class="op">$</span><span class="va">ngr</span><span class="op">[</span><span class="fl">1</span><span class="op">]</span>
 
 <span class="co"># Convert OS Grid reference to BNG</span>
-<span class="fu"><a href="../reference/osg_parse.html">osg_parse</a></span><span class="op">(</span><span class="st">"SN853872"</span><span class="op">)</span></pre></div>
+<span class="fu"><a href="../reference/osg_parse.html">osg_parse</a></span><span class="op">(</span><span class="st">"SN853872"</span><span class="op">)</span></code></pre></div>
 <p>The same function can also convert from BNG to latitude and longitude in the WSGS84 coordinate system (EPSG code: 4326) as in the example below.</p>
-<div class="sourceCode" id="cb12"><pre class="downlit">
-<span class="co"># Convert BNG to WSGS84</span>
-<span class="fu"><a href="../reference/osg_parse.html">osg_parse</a></span><span class="op">(</span>grid_refs <span class="op">=</span> <span class="st">"SN853872"</span>, coord_system <span class="op">=</span> <span class="st">"WGS84"</span><span class="op">)</span></pre></div>
+<div class="sourceCode" id="cb12"><pre class="downlit sourceCode r">
+<code class="sourceCode R"><span class="co"># Convert BNG to WSGS84</span>
+<span class="fu"><a href="../reference/osg_parse.html">osg_parse</a></span><span class="op">(</span>grid_refs <span class="op">=</span> <span class="st">"SN853872"</span>, coord_system <span class="op">=</span> <span class="st">"WGS84"</span><span class="op">)</span></code></pre></div>
 <p>osg_parse() also works with multiple references:</p>
-<div class="sourceCode" id="cb13"><pre class="downlit">
-<span class="fu"><a href="../reference/osg_parse.html">osg_parse</a></span><span class="op">(</span>grid_refs <span class="op">=</span> <span class="va">someStations</span><span class="op">$</span><span class="va">`grid-reference`</span><span class="op">$</span><span class="va">ngr</span><span class="op">)</span></pre></div>
+<div class="sourceCode" id="cb13"><pre class="downlit sourceCode r">
+<code class="sourceCode R"><span class="fu"><a href="../reference/osg_parse.html">osg_parse</a></span><span class="op">(</span>grid_refs <span class="op">=</span> <span class="va">someStations</span><span class="op">$</span><span class="va">`grid-reference`</span><span class="op">$</span><span class="va">ngr</span><span class="op">)</span></code></pre></div>
 </div>
 <div id="get-time-series-data" class="section level3">
 <h3 class="hasAnchor">
@@ -268,8 +268,8 @@
 <li><p><code>cl</code>, This is a cluster object, created by the parallel package. This is set to NULL by default, which sends sequential calls to the server.</p></li>
 </ul>
 <p>Here is how to retrieve mean rainfall (monthly) data for <em>Shin at Lairg (id = 3001)</em> catchment.</p>
-<div class="sourceCode" id="cb14"><pre class="downlit">
-<span class="co"># Fetch only time series data from the waterml2 service</span>
+<div class="sourceCode" id="cb14"><pre class="downlit sourceCode r">
+<code class="sourceCode R"><span class="co"># Fetch only time series data from the waterml2 service</span>
 <span class="va">info</span> <span class="op">&lt;-</span> <span class="fu"><a href="../reference/cmr.html">cmr</a></span><span class="op">(</span>id <span class="op">=</span> <span class="st">"3001"</span><span class="op">)</span>
 <span class="fu"><a href="https://rdrr.io/r/graphics/plot.default.html">plot</a></span><span class="op">(</span><span class="va">info</span><span class="op">)</span>
 
@@ -277,10 +277,10 @@
 <span class="va">info</span> <span class="op">&lt;-</span> <span class="fu"><a href="../reference/cmr.html">cmr</a></span><span class="op">(</span>id <span class="op">=</span> <span class="st">"3001"</span>, metadata <span class="op">=</span> <span class="cn">TRUE</span><span class="op">)</span>
 <span class="fu"><a href="https://rdrr.io/r/graphics/plot.default.html">plot</a></span><span class="op">(</span><span class="va">info</span><span class="op">$</span><span class="va">data</span>, main<span class="op">=</span><span class="fu"><a href="https://rdrr.io/r/base/paste.html">paste</a></span><span class="op">(</span><span class="st">"Monthly rainfall data for the"</span>,
                            <span class="va">info</span><span class="op">$</span><span class="va">meta</span><span class="op">$</span><span class="va">stationName</span>,<span class="st">"catchment"</span><span class="op">)</span>, 
-     xlab<span class="op">=</span><span class="st">""</span>, ylab<span class="op">=</span><span class="va">info</span><span class="op">$</span><span class="va">meta</span><span class="op">$</span><span class="va">units</span><span class="op">)</span></pre></div>
+     xlab<span class="op">=</span><span class="st">""</span>, ylab<span class="op">=</span><span class="va">info</span><span class="op">$</span><span class="va">meta</span><span class="op">$</span><span class="va">units</span><span class="op">)</span></code></pre></div>
 <p>Here is how to retrieve (daily) flow data for <em>Shin at Lairg (id = 3001)</em> catchment.</p>
-<div class="sourceCode" id="cb15"><pre class="downlit">
-<span class="co"># Fetch only time series data</span>
+<div class="sourceCode" id="cb15"><pre class="downlit sourceCode r">
+<code class="sourceCode R"><span class="co"># Fetch only time series data</span>
 <span class="va">info</span> <span class="op">&lt;-</span> <span class="fu"><a href="../reference/gdf.html">gdf</a></span><span class="op">(</span>id <span class="op">=</span> <span class="st">"3001"</span><span class="op">)</span>
 <span class="fu"><a href="https://rdrr.io/r/graphics/plot.default.html">plot</a></span><span class="op">(</span><span class="va">info</span><span class="op">)</span>
 
@@ -289,42 +289,42 @@
 <span class="fu"><a href="https://rdrr.io/r/graphics/plot.default.html">plot</a></span><span class="op">(</span><span class="va">info</span><span class="op">$</span><span class="va">data</span>, main<span class="op">=</span><span class="fu"><a href="https://rdrr.io/r/base/paste.html">paste0</a></span><span class="op">(</span><span class="st">"Daily flow data for the "</span>,
                             <span class="va">info</span><span class="op">$</span><span class="va">meta</span><span class="op">$</span><span class="va">station.name</span>,
                             <span class="st">" catchment ("</span>,
-                            <span class="va">info</span><span class="op">$</span><span class="va">meta</span><span class="op">$</span><span class="va">data.type.units</span>, <span class="st">")"</span><span class="op">)</span><span class="op">)</span></pre></div>
+                            <span class="va">info</span><span class="op">$</span><span class="va">meta</span><span class="op">$</span><span class="va">data.type.units</span>, <span class="st">")"</span><span class="op">)</span><span class="op">)</span></code></pre></div>
 </div>
 <div id="multiple-sites" class="section level3">
 <h3 class="hasAnchor">
 <a href="#multiple-sites" class="anchor"></a>Multiple sites</h3>
 <p>By default, the functions <code>getTS()</code> can be used to fetch time series data from multiple site in a sequential mode (using 1 core):</p>
-<div class="sourceCode" id="cb16"><pre class="downlit">
-<span class="co"># Search data/metadata</span>
+<div class="sourceCode" id="cb16"><pre class="downlit sourceCode r">
+<code class="sourceCode R"><span class="co"># Search data/metadata</span>
 <span class="va">s</span> <span class="op">&lt;-</span> <span class="fu"><a href="../reference/cmr.html">cmr</a></span><span class="op">(</span><span class="fu"><a href="https://rdrr.io/r/base/c.html">c</a></span><span class="op">(</span><span class="fl">3002</span>,<span class="fl">3003</span><span class="op">)</span>, metadata <span class="op">=</span> <span class="cn">TRUE</span><span class="op">)</span>
 
 <span class="co"># s is a list of 2 objects (one object for each site)</span>
 <span class="fu"><a href="https://rdrr.io/r/graphics/plot.default.html">plot</a></span><span class="op">(</span><span class="va">s</span><span class="op">[[</span><span class="fl">1</span><span class="op">]</span><span class="op">]</span><span class="op">$</span><span class="va">data</span>, 
      main <span class="op">=</span> <span class="fu"><a href="https://rdrr.io/r/base/paste.html">paste</a></span><span class="op">(</span><span class="va">s</span><span class="op">[[</span><span class="fl">1</span><span class="op">]</span><span class="op">]</span><span class="op">$</span><span class="va">meta</span><span class="op">$</span><span class="va">station.name</span>, <span class="st">"and"</span>, <span class="va">s</span><span class="op">[[</span><span class="fl">2</span><span class="op">]</span><span class="op">]</span><span class="op">$</span><span class="va">meta</span><span class="op">$</span><span class="va">station.name</span><span class="op">)</span><span class="op">)</span>
-<span class="fu"><a href="https://rdrr.io/r/graphics/lines.html">lines</a></span><span class="op">(</span><span class="va">s</span><span class="op">[[</span><span class="fl">2</span><span class="op">]</span><span class="op">]</span><span class="op">$</span><span class="va">data</span>, col<span class="op">=</span><span class="st">"green"</span><span class="op">)</span></pre></div>
+<span class="fu"><a href="https://rdrr.io/r/graphics/lines.html">lines</a></span><span class="op">(</span><span class="va">s</span><span class="op">[[</span><span class="fl">2</span><span class="op">]</span><span class="op">]</span><span class="op">$</span><span class="va">data</span>, col<span class="op">=</span><span class="st">"green"</span><span class="op">)</span></code></pre></div>
 </div>
 </div>
 <div id="interoperability" class="section level2">
 <h2 class="hasAnchor">
 <a href="#interoperability" class="anchor"></a>Interoperability</h2>
 <p>Upgrade your data.frame to a data.table:</p>
-<div class="sourceCode" id="cb17"><pre class="downlit">
-<span class="kw"><a href="https://rdrr.io/r/base/library.html">library</a></span><span class="op">(</span><span class="va"><a href="https://github.com/rstudio/DT">DT</a></span><span class="op">)</span>
-<span class="fu"><a href="https://rdrr.io/pkg/DT/man/datatable.html">datatable</a></span><span class="op">(</span><span class="fu"><a href="../reference/catalogue.html">catalogue</a></span><span class="op">(</span><span class="op">)</span><span class="op">)</span></pre></div>
+<div class="sourceCode" id="cb17"><pre class="downlit sourceCode r">
+<code class="sourceCode R"><span class="kw"><a href="https://rdrr.io/r/base/library.html">library</a></span><span class="op">(</span><span class="va"><a href="https://github.com/rstudio/DT">DT</a></span><span class="op">)</span>
+<span class="fu"><a href="https://rdrr.io/pkg/DT/man/datatable.html">datatable</a></span><span class="op">(</span><span class="fu"><a href="../reference/catalogue.html">catalogue</a></span><span class="op">(</span><span class="op">)</span><span class="op">)</span></code></pre></div>
 <p>Create interactive maps using leaflet:</p>
-<div class="sourceCode" id="cb18"><pre class="downlit">
-<span class="kw"><a href="https://rdrr.io/r/base/library.html">library</a></span><span class="op">(</span><span class="va"><a href="http://rstudio.github.io/leaflet/">leaflet</a></span><span class="op">)</span>
+<div class="sourceCode" id="cb18"><pre class="downlit sourceCode r">
+<code class="sourceCode R"><span class="kw"><a href="https://rdrr.io/r/base/library.html">library</a></span><span class="op">(</span><span class="va"><a href="https://rstudio.github.io/leaflet/">leaflet</a></span><span class="op">)</span>
 
 <span class="fu"><a href="https://rdrr.io/pkg/leaflet/man/leaflet.html">leaflet</a></span><span class="op">(</span>data <span class="op">=</span> <span class="va">someStations</span><span class="op">)</span> <span class="op">%&gt;%</span> <span class="fu"><a href="https://rdrr.io/pkg/leaflet/man/map-layers.html">addTiles</a></span><span class="op">(</span><span class="op">)</span> <span class="op">%&gt;%</span>
-  <span class="fu"><a href="https://rdrr.io/pkg/leaflet/man/map-layers.html">addMarkers</a></span><span class="op">(</span><span class="op">~</span><span class="va">longitude</span>, <span class="op">~</span><span class="va">latitude</span>, popup <span class="op">=</span> <span class="op">~</span><span class="fu"><a href="https://rdrr.io/r/base/character.html">as.character</a></span><span class="op">(</span><span class="fu"><a href="https://rdrr.io/r/base/paste.html">paste</a></span><span class="op">(</span><span class="va">id</span>,<span class="va">name</span><span class="op">)</span><span class="op">)</span><span class="op">)</span></pre></div>
+  <span class="fu"><a href="https://rdrr.io/pkg/leaflet/man/map-layers.html">addMarkers</a></span><span class="op">(</span><span class="op">~</span><span class="va">longitude</span>, <span class="op">~</span><span class="va">latitude</span>, popup <span class="op">=</span> <span class="op">~</span><span class="fu"><a href="https://rdrr.io/r/base/character.html">as.character</a></span><span class="op">(</span><span class="fu"><a href="https://rdrr.io/r/base/paste.html">paste</a></span><span class="op">(</span><span class="va">id</span>,<span class="va">name</span><span class="op">)</span><span class="op">)</span><span class="op">)</span></code></pre></div>
 <p>Interactive plots using dygraphs:</p>
-<div class="sourceCode" id="cb19"><pre class="downlit">
-<span class="kw"><a href="https://rdrr.io/r/base/library.html">library</a></span><span class="op">(</span><span class="va"><a href="https://github.com/rstudio/dygraphs">dygraphs</a></span><span class="op">)</span>
-<span class="fu"><a href="https://rdrr.io/pkg/dygraphs/man/dygraph.html">dygraph</a></span><span class="op">(</span><span class="va">info</span><span class="op">$</span><span class="va">data</span><span class="op">)</span> <span class="op">%&gt;%</span> <span class="fu"><a href="https://rdrr.io/pkg/dygraphs/man/dyRangeSelector.html">dyRangeSelector</a></span><span class="op">(</span><span class="op">)</span></pre></div>
+<div class="sourceCode" id="cb19"><pre class="downlit sourceCode r">
+<code class="sourceCode R"><span class="kw"><a href="https://rdrr.io/r/base/library.html">library</a></span><span class="op">(</span><span class="va"><a href="https://github.com/rstudio/dygraphs">dygraphs</a></span><span class="op">)</span>
+<span class="fu"><a href="https://rdrr.io/pkg/dygraphs/man/dygraph.html">dygraph</a></span><span class="op">(</span><span class="va">info</span><span class="op">$</span><span class="va">data</span><span class="op">)</span> <span class="op">%&gt;%</span> <span class="fu"><a href="https://rdrr.io/pkg/dygraphs/man/dyRangeSelector.html">dyRangeSelector</a></span><span class="op">(</span><span class="op">)</span></code></pre></div>
 <p>Sequential vs Concurrent requests: a simple benchmark test</p>
-<div class="sourceCode" id="cb20"><pre class="downlit">
-<span class="kw"><a href="https://rdrr.io/r/base/library.html">library</a></span><span class="op">(</span><span class="va">parallel</span><span class="op">)</span>
+<div class="sourceCode" id="cb20"><pre class="downlit sourceCode r">
+<code class="sourceCode R"><span class="kw"><a href="https://rdrr.io/r/base/library.html">library</a></span><span class="op">(</span><span class="va">parallel</span><span class="op">)</span>
 <span class="co"># Use detectCores() to find out many cores are available on your machine</span>
 <span class="va">cl</span> <span class="op">&lt;-</span> <span class="fu"><a href="https://rdrr.io/r/parallel/makeCluster.html">makeCluster</a></span><span class="op">(</span><span class="fu"><a href="https://rdrr.io/r/base/options.html">getOption</a></span><span class="op">(</span><span class="st">"cl.cores"</span>, <span class="fu"><a href="https://rdrr.io/r/parallel/detectCores.html">detectCores</a></span><span class="op">(</span><span class="op">)</span><span class="op">)</span><span class="op">)</span>
 
@@ -337,10 +337,10 @@
 <span class="co"># Get flow data with a concurrent approach (using `parLapply()`)</span>
 <span class="fu"><a href="https://rdrr.io/r/base/system.time.html">system.time</a></span><span class="op">(</span><span class="va">s2</span> <span class="op">&lt;-</span> <span class="fu"><a href="../reference/gdf.html">gdf</a></span><span class="op">(</span>id <span class="op">=</span> <span class="va">someStations</span><span class="op">$</span><span class="va">id</span>, cl <span class="op">=</span> <span class="va">cl</span><span class="op">)</span><span class="op">)</span>
 
-<span class="fu"><a href="https://rdrr.io/r/parallel/makeCluster.html">stopCluster</a></span><span class="op">(</span><span class="va">cl</span><span class="op">)</span></pre></div>
+<span class="fu"><a href="https://rdrr.io/r/parallel/makeCluster.html">stopCluster</a></span><span class="op">(</span><span class="va">cl</span><span class="op">)</span></code></pre></div>
 <p>The measured flows are expected to increase with the catchment area. Let’s show this simple regression on a plot:</p>
-<div class="sourceCode" id="cb21"><pre class="downlit">
-<span class="co"># Calculate the mean flow for each catchment</span>
+<div class="sourceCode" id="cb21"><pre class="downlit sourceCode r">
+<code class="sourceCode R"><span class="co"># Calculate the mean flow for each catchment</span>
 <span class="va">someStations</span><span class="op">$</span><span class="va">meangdf</span> <span class="op">&lt;-</span> <span class="fu"><a href="https://rdrr.io/r/base/unlist.html">unlist</a></span><span class="op">(</span><span class="fu"><a href="https://rdrr.io/r/base/lapply.html">lapply</a></span><span class="op">(</span><span class="va">s2</span>, <span class="va">mean</span><span class="op">)</span><span class="op">)</span>
 
 <span class="co"># Linear model</span>
@@ -349,7 +349,7 @@
   <span class="fu"><a href="https://ggplot2.tidyverse.org/reference/geom_point.html">geom_point</a></span><span class="op">(</span><span class="op">)</span> <span class="op">+</span>
   <span class="fu"><a href="https://ggplot2.tidyverse.org/reference/geom_smooth.html">stat_smooth</a></span><span class="op">(</span>method <span class="op">=</span> <span class="st">"lm"</span>, col <span class="op">=</span> <span class="st">"red"</span><span class="op">)</span> <span class="op">+</span>
   <span class="fu"><a href="https://ggplot2.tidyverse.org/reference/labs.html">xlab</a></span><span class="op">(</span><span class="fu"><a href="https://rdrr.io/r/base/expression.html">expression</a></span><span class="op">(</span><span class="fu"><a href="https://rdrr.io/r/base/paste.html">paste</a></span><span class="op">(</span><span class="st">"Catchment area [Km^2]"</span>,sep<span class="op">=</span><span class="st">""</span><span class="op">)</span><span class="op">)</span><span class="op">)</span> <span class="op">+</span>
-  <span class="fu"><a href="https://ggplot2.tidyverse.org/reference/labs.html">ylab</a></span><span class="op">(</span><span class="fu"><a href="https://rdrr.io/r/base/expression.html">expression</a></span><span class="op">(</span><span class="fu"><a href="https://rdrr.io/r/base/paste.html">paste</a></span><span class="op">(</span><span class="st">"Mean flow [m^3/s]"</span>,sep<span class="op">=</span><span class="st">""</span><span class="op">)</span><span class="op">)</span><span class="op">)</span></pre></div>
+  <span class="fu"><a href="https://ggplot2.tidyverse.org/reference/labs.html">ylab</a></span><span class="op">(</span><span class="fu"><a href="https://rdrr.io/r/base/expression.html">expression</a></span><span class="op">(</span><span class="fu"><a href="https://rdrr.io/r/base/paste.html">paste</a></span><span class="op">(</span><span class="st">"Mean flow [m^3/s]"</span>,sep<span class="op">=</span><span class="st">""</span><span class="op">)</span><span class="op">)</span><span class="op">)</span></code></pre></div>
 </div>
   </div>
 

--- a/docs/articles/rnrfa-vignette_files/header-attrs-2.10/header-attrs.js
+++ b/docs/articles/rnrfa-vignette_files/header-attrs-2.10/header-attrs.js
@@ -1,0 +1,12 @@
+// Pandoc 2.9 adds attributes on both header and div. We remove the former (to
+// be compatible with the behavior of Pandoc < 2.8).
+document.addEventListener('DOMContentLoaded', function(e) {
+  var hs = document.querySelectorAll("div.section[class*='level'] > :first-child");
+  var i, h, a;
+  for (i = 0; i < hs.length; i++) {
+    h = hs[i];
+    if (!/^h[1-6]$/i.test(h.tagName)) continue;  // it should be a header h1-h6
+    a = h.attributes;
+    while (a.length > 0) h.removeAttribute(a[0].name);
+  }
+});

--- a/docs/index.html
+++ b/docs/index.html
@@ -104,15 +104,15 @@
 <h2 class="hasAnchor">
 <a href="#installation" class="anchor"></a>Installation</h2>
 <p>The stable version of the <strong>rnrfa</strong> package is available from CRAN:</p>
-<div class="sourceCode" id="cb1"><pre class="downlit">
-<span class="fu"><a href="https://rdrr.io/r/utils/install.packages.html">install.packages</a></span><span class="op">(</span><span class="st">"rnrfa"</span><span class="op">)</span></pre></div>
+<div class="sourceCode" id="cb1"><pre class="downlit sourceCode r">
+<code class="sourceCode R"><span class="fu"><a href="https://rdrr.io/r/utils/install.packages.html">install.packages</a></span><span class="op">(</span><span class="st">"rnrfa"</span><span class="op">)</span></code></pre></div>
 <p>Or the development version from GitHub using the package <code>remotes</code>:</p>
-<div class="sourceCode" id="cb2"><pre class="downlit">
-<span class="fu"><a href="https://rdrr.io/r/utils/install.packages.html">install.packages</a></span><span class="op">(</span><span class="st">"remotes"</span><span class="op">)</span>
-<span class="fu">remotes</span><span class="fu">::</span><span class="fu"><a href="https://remotes.r-lib.org/reference/install_github.html">install_github</a></span><span class="op">(</span><span class="st">"ilapros/rnrfa"</span><span class="op">)</span></pre></div>
+<div class="sourceCode" id="cb2"><pre class="downlit sourceCode r">
+<code class="sourceCode R"><span class="fu"><a href="https://rdrr.io/r/utils/install.packages.html">install.packages</a></span><span class="op">(</span><span class="st">"remotes"</span><span class="op">)</span>
+<span class="fu">remotes</span><span class="fu">::</span><span class="fu"><a href="https://remotes.r-lib.org/reference/install_github.html">install_github</a></span><span class="op">(</span><span class="st">"ilapros/rnrfa"</span><span class="op">)</span></code></pre></div>
 <p>Now, load the rnrfa package:</p>
-<div class="sourceCode" id="cb3"><pre class="downlit">
-<span class="kw"><a href="https://rdrr.io/r/base/library.html">library</a></span><span class="op">(</span><span class="va"><a href="http://ilapros.github.io/rnrfa/">rnrfa</a></span><span class="op">)</span></pre></div>
+<div class="sourceCode" id="cb3"><pre class="downlit sourceCode r">
+<code class="sourceCode R"><span class="kw"><a href="https://rdrr.io/r/base/library.html">library</a></span><span class="op">(</span><span class="va"><a href="http://ilapros.github.io/rnrfa/">rnrfa</a></span><span class="op">)</span></code></pre></div>
 </div>
 <div id="examples" class="section level2">
 <h2 class="hasAnchor">
@@ -121,33 +121,33 @@
 <h3 class="hasAnchor">
 <a href="#retrieve-information-for-all-the-stations-in-the-catalogue" class="anchor"></a>Retrieve information for all the stations in the catalogue</h3>
 <p>The R function that deals with the NRFA catalogue to retrieve the full list of monitoring stations is called catalogue(). The function, used with no inputs, requests the full list of gauging stations with associated metadata. The output is a dataframe containing one record for each station and as many columns as the number of metadata entries available.</p>
-<div class="sourceCode" id="cb4"><pre class="downlit">
-<span class="va">allStations</span> <span class="op">&lt;-</span> <span class="fu"><a href="reference/catalogue.html">catalogue</a></span><span class="op">(</span><span class="op">)</span></pre></div>
+<div class="sourceCode" id="cb4"><pre class="downlit sourceCode r">
+<code class="sourceCode R"><span class="va">allStations</span> <span class="op">&lt;-</span> <span class="fu"><a href="reference/catalogue.html">catalogue</a></span><span class="op">(</span><span class="op">)</span></code></pre></div>
 <p>The same function catalogue() can be used to filter stations based on a bounding box or any of the metadata entries.</p>
-<div class="sourceCode" id="cb5"><pre class="downlit">
-<span class="co"># Define a bounding box:</span>
+<div class="sourceCode" id="cb5"><pre class="downlit sourceCode r">
+<code class="sourceCode R"><span class="co"># Define a bounding box:</span>
 <span class="va">bbox</span> <span class="op">&lt;-</span> <span class="fu"><a href="https://rdrr.io/r/base/list.html">list</a></span><span class="op">(</span>lon_min<span class="op">=</span><span class="op">-</span><span class="fl">3.82</span>, lon_max<span class="op">=</span><span class="op">-</span><span class="fl">3.63</span>, lat_min<span class="op">=</span><span class="fl">52.43</span>, lat_max<span class="op">=</span><span class="fl">52.52</span><span class="op">)</span>
 
 <span class="co"># Filter stations based on bounding box</span>
-<span class="va">someStations</span> <span class="op">&lt;-</span> <span class="fu"><a href="reference/catalogue.html">catalogue</a></span><span class="op">(</span><span class="va">bbox</span><span class="op">)</span></pre></div>
+<span class="va">someStations</span> <span class="op">&lt;-</span> <span class="fu"><a href="reference/catalogue.html">catalogue</a></span><span class="op">(</span><span class="va">bbox</span><span class="op">)</span></code></pre></div>
 </div>
 <div id="conversions-of-os-grid-references" class="section level3">
 <h3 class="hasAnchor">
 <a href="#conversions-of-os-grid-references" class="anchor"></a>Conversions of OS grid references</h3>
 <p>The only geospatial information contained in the list of station in the catalogue is the OS grid reference (column “gridRef”). The RNRFA package allows convenient conversion to more standard coordinate systems. The function “osg_parse()”, for example, converts the string to easting and northing in the BNG coordinate system (EPSG code: 27700), as in the example below:</p>
-<div class="sourceCode" id="cb6"><pre class="downlit">
-<span class="co"># Where is the first catchment located?</span>
+<div class="sourceCode" id="cb6"><pre class="downlit sourceCode r">
+<code class="sourceCode R"><span class="co"># Where is the first catchment located?</span>
 <span class="va">someStations</span><span class="op">$</span><span class="va">`grid-reference`</span><span class="op">$</span><span class="va">ngr</span><span class="op">[</span><span class="fl">1</span><span class="op">]</span>
 
 <span class="co"># Convert OS Grid reference to BNG</span>
-<span class="fu"><a href="reference/osg_parse.html">osg_parse</a></span><span class="op">(</span>grid_refs <span class="op">=</span> <span class="st">"SN853872"</span><span class="op">)</span></pre></div>
+<span class="fu"><a href="reference/osg_parse.html">osg_parse</a></span><span class="op">(</span>grid_refs <span class="op">=</span> <span class="st">"SN853872"</span><span class="op">)</span></code></pre></div>
 <p>The same function can also convert from BNG to latitude and longitude in the WSGS84 coordinate system (EPSG code: 4326) as in the example below.</p>
-<div class="sourceCode" id="cb7"><pre class="downlit">
-<span class="co"># Convert BNG to WSGS84</span>
-<span class="fu"><a href="reference/osg_parse.html">osg_parse</a></span><span class="op">(</span>grid_refs <span class="op">=</span> <span class="st">"SN853872"</span>, coord_system <span class="op">=</span> <span class="st">"WGS84"</span><span class="op">)</span></pre></div>
+<div class="sourceCode" id="cb7"><pre class="downlit sourceCode r">
+<code class="sourceCode R"><span class="co"># Convert BNG to WSGS84</span>
+<span class="fu"><a href="reference/osg_parse.html">osg_parse</a></span><span class="op">(</span>grid_refs <span class="op">=</span> <span class="st">"SN853872"</span>, coord_system <span class="op">=</span> <span class="st">"WGS84"</span><span class="op">)</span></code></pre></div>
 <p>osg_parse() also works with multiple references:</p>
-<div class="sourceCode" id="cb8"><pre class="downlit">
-<span class="fu"><a href="reference/osg_parse.html">osg_parse</a></span><span class="op">(</span><span class="va">someStations</span><span class="op">$</span><span class="va">`grid-reference`</span><span class="op">$</span><span class="va">ngr</span><span class="op">)</span></pre></div>
+<div class="sourceCode" id="cb8"><pre class="downlit sourceCode r">
+<code class="sourceCode R"><span class="fu"><a href="reference/osg_parse.html">osg_parse</a></span><span class="op">(</span><span class="va">someStations</span><span class="op">$</span><span class="va">`grid-reference`</span><span class="op">$</span><span class="va">ngr</span><span class="op">)</span></code></pre></div>
 </div>
 <div id="time-series-data" class="section level3">
 <h3 class="hasAnchor">
@@ -155,13 +155,13 @@
 <p>The first column of the table “someStations” contains the id number. This can be used to retrieve time series data and convert waterml2 files to time series object (of class zoo).</p>
 <p>The National River Flow Archive serves two types of time series data: gauged daily flow and catchment mean rainfall.</p>
 <p>Catchment mean rainfall:</p>
-<div class="sourceCode" id="cb9"><pre class="downlit">
-<span class="va">info</span> <span class="op">&lt;-</span> <span class="fu"><a href="reference/cmr.html">cmr</a></span><span class="op">(</span>id <span class="op">=</span> <span class="st">"3001"</span><span class="op">)</span>
-<span class="fu"><a href="https://rdrr.io/r/graphics/plot.default.html">plot</a></span><span class="op">(</span><span class="va">info</span><span class="op">)</span></pre></div>
+<div class="sourceCode" id="cb9"><pre class="downlit sourceCode r">
+<code class="sourceCode R"><span class="va">info</span> <span class="op">&lt;-</span> <span class="fu"><a href="reference/cmr.html">cmr</a></span><span class="op">(</span>id <span class="op">=</span> <span class="st">"3001"</span><span class="op">)</span>
+<span class="fu"><a href="https://rdrr.io/r/graphics/plot.default.html">plot</a></span><span class="op">(</span><span class="va">info</span><span class="op">)</span></code></pre></div>
 <p>Gauged daily flow:</p>
-<div class="sourceCode" id="cb10"><pre class="downlit">
-<span class="va">info</span> <span class="op">&lt;-</span> <span class="fu"><a href="reference/gdf.html">gdf</a></span><span class="op">(</span>id <span class="op">=</span> <span class="st">"3001"</span><span class="op">)</span>
-<span class="fu"><a href="https://rdrr.io/r/graphics/plot.default.html">plot</a></span><span class="op">(</span><span class="va">info</span><span class="op">)</span></pre></div>
+<div class="sourceCode" id="cb10"><pre class="downlit sourceCode r">
+<code class="sourceCode R"><span class="va">info</span> <span class="op">&lt;-</span> <span class="fu"><a href="reference/gdf.html">gdf</a></span><span class="op">(</span>id <span class="op">=</span> <span class="st">"3001"</span><span class="op">)</span>
+<span class="fu"><a href="https://rdrr.io/r/graphics/plot.default.html">plot</a></span><span class="op">(</span><span class="va">info</span><span class="op">)</span></code></pre></div>
 <p>For more examples and details, please see the <a href="https://github.com/ilapros/rnrfa/blob/master/vignettes/rnrfa-vignette.Rmd">vignette</a>.</p>
 </div>
 <div id="terms-and-conditions" class="section level3">

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -1,7 +1,7 @@
-pandoc: 2.11.2
+pandoc: 2.14.0.3
 pkgdown: 1.6.1
 pkgdown_sha: ~
 articles:
   rnrfa-vignette: rnrfa-vignette.html
-last_built: 2021-03-12T18:05Z
+last_built: 2021-11-21T19:47Z
 

--- a/docs/reference/osg_parse.html
+++ b/docs/reference/osg_parse.html
@@ -165,6 +165,9 @@ latitude and longitude coordinates.</p>
 
   <span class='co'># multiple entries</span>
   <span class='fu'>osg_parse</span><span class='op'>(</span>grid_refs <span class='op'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/c.html'>c</a></span><span class='op'>(</span><span class='st'>"SN831869"</span>,<span class='st'>"SN829838"</span><span class='op'>)</span><span class='op'>)</span>
+  
+  <span class='co'># multiple entries with missing values, NA will be returned</span>
+  <span class='fu'>osg_parse</span><span class='op'>(</span>grid_refs <span class='op'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/c.html'>c</a></span><span class='op'>(</span><span class='st'>"SN831869"</span>,<span class='cn'>NA</span>, <span class='st'>"SN829838"</span>, <span class='cn'>NA</span><span class='op'>)</span><span class='op'>)</span>
 <span class='op'>}</span>
 
 </div></pre>

--- a/man/osg_parse.Rd
+++ b/man/osg_parse.Rd
@@ -30,6 +30,9 @@ easting/northing or latitude/longitude coordinates.
 
   # multiple entries
   osg_parse(grid_refs = c("SN831869","SN829838"))
+  
+  # multiple entries with missing values, NA will be returned
+  osg_parse(grid_refs = c("SN831869",NA, "SN829838", NA))
 }
 
 }

--- a/tests/testthat/test-osg_parse.R
+++ b/tests/testthat/test-osg_parse.R
@@ -37,6 +37,17 @@ test_that("Test grid references from various areas", {
 
 })
 
+test_that("Test grid references deal with missing values", {
+  
+  expect_that(osg_parse(c("SN831869", NA, "SN829838")),
+              equals(structure(list(easting = c(283100, NA, 282900),
+                                    northing = c(286900, NA, 283800)),
+                               .Names = c("easting", "northing"))))
+  
+  closeAllConnections()
+  
+})
+
 
 
 # crs 4326


### PR DESCRIPTION
Hi @ilapros,

I was using the `osg_parse()` function last week and it was invaluable in getting us some missing values from map references. The only issue we had was that some of the data had missing values and whilst these were present the parsing failed. I understand that this might be the intended use case for the `osg_parse()` function but I thought it might be of use to add the ability to deal with missing values. I completely understand if this is not what you would intend the function to do but wanted to give you the option. 

I have also rebuilt the documentation and pkgdown pages. 

Hope this helps.

Thanks,

Andrew

